### PR TITLE
Address Comments

### DIFF
--- a/lib/msf/util/windows_registry_parser.rb
+++ b/lib/msf/util/windows_registry_parser.rb
@@ -347,11 +347,7 @@ module Util
       res = []
       value_list = get_value_blocks(key.data.offset_value_list, key.data.num_values + 1)
       value_list.each do |value|
-        if value.data.flag > 0
-          res << value.data.name
-        else
-          res << 'default'.b
-        end
+        res << (value.data.flag > 0 ? value.data.name : nil)
       end
       res
     end

--- a/modules/auxiliary/gather/windows_secrets_dump.rb
+++ b/modules/auxiliary/gather/windows_secrets_dump.rb
@@ -896,15 +896,17 @@ class MetasploitModule < Msf::Auxiliary
         vprint_bad("Error when reporting #{print_name} NTLM hash")
       end
 
+
+      raw_passwd = secret_item.unpack('H*')[0]
+      credential_opts[:type] = :password
+      unless report_creds(print_name, raw_passwd, credential_opts)
+        vprint_bad("Error when reporting #{print_name} raw password hash")
+      end
+      secret = "#{print_name}:plain_password_hex:#{raw_passwd}\n"
+
       extra_secret = get_machine_kerberos_keys(secret_item, print_name)
       if extra_secret.empty?
         vprint_status('Could not calculate machine account Kerberos keys, printing plain password (hex encoded)')
-        raw_passwd = secret_item.unpack('H*')[0]
-        credential_opts[:type] = :password
-        unless report_creds(print_name, raw_passwd, credential_opts)
-          vprint_bad("Error when reporting #{print_name} raw password hash")
-        end
-        extra_secret = ["#{print_name}:plain_password_hex:#{raw_passwd}"]
       else
         credential_opts[:type] = :nonreplayable_hash
         extra_secret.each do |sec|
@@ -915,14 +917,14 @@ class MetasploitModule < Msf::Auxiliary
         end
       end
 
-      secret = extra_secret.concat(secret_ary).join("\n")
+      secret << extra_secret.concat(secret_ary).join("\n")
     end
 
-    if secret != ''
-      print_line(secret)
-    else
+    if secret.empty?
       print_line(Rex::Text.to_hex_dump(secret_item).strip)
       print_line("Hex string: #{secret_item.unpack('H*')[0]}")
+    else
+      print_line(secret)
     end
     print_line
   end


### PR DESCRIPTION
This proposes changes that would address my comments from rapid7/metasploit-framework#13995.

Changes include:
* Adjusted one line of whitespace in `dump_cached_hashes`
* Altered the handling of the machine kerberos keys to
    * Always show the `plain_password_hex` value of the machine account kerberos keys even if the calculation was successful
    * Consolidated the two `aes###_cts_hmac_sha1_96_key` functions into one to resuse code with an optional algorithm argument
* Changed to returning `nil` instead of `'default'` for registry values that have no data

I tested the AES function before and after to ensure that the values were the exact same.