### PR TITLE
Report the ICertPassage (MS-ICPR) with the new API

### DIFF
--- a/lib/msf/core/exploit/remote/ms_icpr.rb
+++ b/lib/msf/core/exploit/remote/ms_icpr.rb
@@ -129,6 +129,22 @@ module Exploit::Remote::MsIcpr
     )
     vprint_good('Bound to \\cert')
 
+    report_service(
+      name: 'ICertPassage',
+      resource: { dcerpc: { pipe: 'cert' } },
+      host: tree.client.dispatcher.tcp_socket.peerhost,
+      port: tree.client.dispatcher.tcp_socket.peerport,
+      proto: 'tcp',
+      parents: {
+          name: 'dcerpc',
+          info: "Module: #{fullname}",
+          host: tree.client.dispatcher.tcp_socket.peerhost,
+          port: tree.client.dispatcher.tcp_socket.peerport,
+          proto: 'tcp',
+          resource: { smb: { share: 'IPC$' } }
+        }
+      )
+
     icpr
   end
 

--- a/lib/msf/core/exploit/remote/smb/client/ipc.rb
+++ b/lib/msf/core/exploit/remote/smb/client/ipc.rb
@@ -34,12 +34,19 @@ module Msf
       end
 
       report_service(
+        name: 'dcerpc',
+        info: "Module: #{fullname}",
         host: simple.peerhost,
         port: simple.peerport,
-        host_name: simple.client.default_name,
         proto: 'tcp',
-        name: 'smb',
-        info: "Module: #{fullname}, last negotiated version: SMBv#{simple.client.negotiated_smb_version} (dialect = #{simple.client.dialect})"
+        resource: { smb: { share: 'IPC$' } },
+        parents: {
+          name: 'smb',
+          host: simple.peerhost,
+          port: simple.peerport,
+          proto: 'tcp',
+          info: "Module: #{fullname}, last negotiated version: SMBv#{simple.client.negotiated_smb_version} (dialect = #{simple.client.dialect})"
+        }
       )
 
       ipc_tree


### PR DESCRIPTION
While reviewing the code for the new API I thought it'd be easiest to test it out with some real cases. While doing so I updated a couple of libraries so that when the `icpr_cert` module is run, we report the ICertPassage -> DCERPC -> SMB service chain accurrately.

Happy to postpone landing this until I can work through the `services -d` issue. Once I got the service definition written correctly, everything started working. It was a bit tricky though to find the right combination of host/port/proto keys for each of the services and when it was wrong, `#report_service` would throw a stack trace. I think it would be really helpful to do some extra validation on those keys before we merge the final work to avoid that exception.

```
msf auxiliary(admin/dcerpc/icpr_cert) > run
[*] Running module against 192.168.159.10
[+] 192.168.159.10:445 - The requested certificate was issued.
[*] 192.168.159.10:445 - Certificate Policies:
[*] 192.168.159.10:445 - Certificate Email: smcintyre@msflab.local
[*] 192.168.159.10:445 - Certificate UPN: smcintyre@msflab.local
[*] 192.168.159.10:445 - Certificate stored at: /home/smcintyre/.msf4/loot/20251009171943_default_192.168.159.10_windows.ad.cs_898362.pfx
[*] Auxiliary module execution completed
msf auxiliary(admin/dcerpc/icpr_cert) > services 
Services
========

host            port  proto  name          state  info                                                                                         resource                    parents
----            ----  -----  ----          -----  ----                                                                                         --------                    -------
192.168.159.10  445   tcp    dcerpc        open   Module: auxiliary/admin/dcerpc/icpr_cert                                                     {"smb":{"share":"IPC$"}}    smb (445/tcp)
192.168.159.10  445   tcp    smb           open   Module: auxiliary/admin/dcerpc/icpr_cert, last negotiated version: SMBv3 (dialect = 0x0311)  {}
192.168.159.10  445   tcp    icertpassage  open                                                                                                {"dcerpc":{"pipe":"cert"}}  dcerpc (445/tcp)

msf auxiliary(admin/dcerpc/icpr_cert) > services -d
[-] Error while running command services: Couldn't find Mdm::Service with 'id'=239

Call stack:
/home/smcintyre/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/activerecord-7.2.2.1/lib/active_record/core.rb:268:in `find'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/core/db_manager/service.rb:9:in `block (2 levels) in delete_service'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/core/db_manager/service.rb:8:in `each'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/core/db_manager/service.rb:8:in `block in delete_service'
/home/smcintyre/.rvm/gems/ruby-3.3.8@metasploit-framework/gems/activerecord-7.2.2.1/lib/active_record/connection_adapters/abstract/connection_pool.rb:415:in `with_connection'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/core/db_manager/service.rb:6:in `delete_service'
/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/data_service/proxy/service_data_proxy.rb:58:in `block in delete_service'
/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/data_service/proxy/core.rb:164:in `data_service_operation'
/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/data_service/proxy/service_data_proxy.rb:57:in `delete_service'
/home/smcintyre/Repositories/metasploit-framework/lib/msf/ui/console/command_dispatcher/db.rb:1011:in `cmd_services'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:582:in `run_command'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:531:in `block in run_single'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:525:in `each'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/dispatcher_shell.rb:525:in `run_single'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell.rb:165:in `block in run'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell.rb:309:in `block in with_history_manager_context'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell/history_manager.rb:35:in `with_context'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell.rb:306:in `with_history_manager_context'
/home/smcintyre/Repositories/metasploit-framework/lib/rex/ui/text/shell.rb:133:in `run'
/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/console.rb:54:in `start'
/home/smcintyre/Repositories/metasploit-framework/lib/metasploit/framework/command/base.rb:82:in `start'
./msfconsole:23:in `<main>'
msf auxiliary(admin/dcerpc/icpr_cert) > run
[*] Running module against 192.168.159.10
[+] 192.168.159.10:445 - The requested certificate was issued.
[*] 192.168.159.10:445 - Certificate Policies:
[*] 192.168.159.10:445 - Certificate Email: smcintyre@msflab.local
[*] 192.168.159.10:445 - Certificate UPN: smcintyre@msflab.local
[*] 192.168.159.10:445 - Certificate stored at: /home/smcintyre/.msf4/loot/20251009171953_default_192.168.159.10_windows.ad.cs_440695.pfx
[*] Auxiliary module execution completed
msf auxiliary(admin/dcerpc/icpr_cert) >
```

While experimenting with this, I *really* like how I can tag the `ICertPassage` service's parent as being `dcerpc` and it still maintains it's parent to SMB. Nice job.